### PR TITLE
Fixed compile errors (comparing signed value with unsigned).

### DIFF
--- a/src/fontem.c
+++ b/src/fontem.c
@@ -237,9 +237,9 @@ void store_glyph(FT_Face *face, FT_GlyphSlotRec *glyph,
 	if (bitmap->rows && bitmap->width) {
 		fprintf(c, "/** Bitmap definition for character '%c'. */\n", ch);
 		fprintf(c, "static const uint8_t %s[] %s= {\n", bname, get_section(bname));
-		for (int y = 0; y < bitmap->rows; y++) {
+		for (unsigned int y = 0; y < bitmap->rows; y++) {
 			fprintf(c, "\t");
-			for (int x = 0; x < bitmap->width; x++)
+			for (unsigned int x = 0; x < bitmap->width; x++)
 				fprintf(c, "0x%02x, ", (unsigned char)bitmap->buffer[y * bitmap->width + x]);
 			fprintf(c, "\n");
 		}


### PR DESCRIPTION
Fixed two compile errors by changing loop variable type as defined in [Freetype API reference](https://www.freetype.org/freetype2/docs/reference/ft2-basic_types.html#FT_Bitmap).