### PR TITLE
Font compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Command line parameters
       -c, --chars=string     List of characters to produce (default: "!@#$%^&*()_+-={}|[]\:";'<>?,./`~ ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
       -n, --name=file        Output name (without extension) (default: null)
       -d, --dir=dir          Output directory (default: ".")
+      --rle                  Use RLE compression
 
     Help options:
       -?, --help             Show this help message

--- a/src/fontem.c
+++ b/src/fontem.c
@@ -62,7 +62,7 @@ int main(int argc, const char *argv[])
 {
 	setlocale(LC_ALL, "");
 	
-	int len, error;
+	int len, error, rle = 0;
 
 	char *font_filename = NULL;
 	char *char_list = strdup(DEFAULT_CHAR_LIST);
@@ -71,12 +71,13 @@ int main(int argc, const char *argv[])
 	int font_size = 10;
 
 	struct poptOption opts[] = {
-		{ "font",    'f', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_filename, 1, "Font filename",		     "file"    },
-		{ "size",    's', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,    &font_size,     1, "Font size",			     "integer" },
-		{ "chars",   'c', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &char_list,     1, "List of characters to produce",   "string"  },
-		{ "name",    'n', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &output_name,   1, "Output name (without extension)", "file"    },
-		{ "dir",     'd', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &output_dir,    1, "Output directory",		     "dir"     },
-		{ "section", 0,	  POPT_ARG_STRING,							   &section,       1, "Section for font data",	     "name"    },
+		{ "font",     'f', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_filename, 1, "Font filename",		     "file"    },
+		{ "size",     's', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,    &font_size,     1, "Font size",			     "integer" },
+		{ "chars",    'c', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &char_list,     1, "List of characters to produce",   "string"  },
+		{ "name",     'n', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &output_name,   1, "Output name (without extension)", "file"    },
+		{ "dir",      'd', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &output_dir,    1, "Output directory",		     "dir"     },
+		{ "section",  0,   POPT_ARG_STRING,								&section,       1, "Section for font data",	     "name"    },
+		{ "rle",      0,   POPT_ARG_VAL,								&rle,           1, "Use RLE compression",        NULL },
 		POPT_AUTOHELP
 		POPT_TABLEEND
 	};
@@ -98,6 +99,11 @@ int main(int argc, const char *argv[])
 
 	if (output_name == NULL) {
 		fprintf(stderr, "ERROR: You must specify an output name.\n");
+		return 1;
+	}
+	
+	if (rle) {
+		fprintf(stderr, "ERROR: RLE compression is not supported yet.\n");
 		return 1;
 	}
 

--- a/src/fontem.c
+++ b/src/fontem.c
@@ -237,6 +237,7 @@ int main(int argc, const char *argv[])
 		"\t.descender = %d,\n" \
 		"\t.height = %d,\n" \
 		"\t.glyphs = glyphs_%s_%d,\n" \
+		"\t.compressed = %u,\n" \
 		"};\n\n",
 		output_name_c, font_size, get_section(output_name_c),
 		font_name, face->style_name, font_size, FONT_DPI,
@@ -244,7 +245,7 @@ int main(int argc, const char *argv[])
 		(int)face->size->metrics.ascender / 64,
 		(int)face->size->metrics.descender / 64,
 		(int)face->size->metrics.height / 64,
-		output_name_c, font_size);
+		output_name_c, font_size, rle);
 
 	// Add the reference to the .h
 	fprintf(h, "extern const struct font font_%s_%d;\n\n", output_name_c, font_size);

--- a/src/fontrender_rgba32.c
+++ b/src/fontrender_rgba32.c
@@ -22,29 +22,66 @@ int font_draw_glyph_RGBA32(const struct font *font,
 	uint8_t g = rgba32_get_g(rgb);
 	uint8_t b = rgba32_get_b(rgb);
 	
-	for (int row = 0; row < glyph->rows; row++) {
-		int yofs = row + y + (font->ascender - glyph->top);
-
-		if (yofs < 0) continue;
-		if (yofs >= height) break;
-
-		for (int col = 0; col < glyph->cols; col++) {
-			int xofs = col + x + glyph->left;
-
-			if (xofs < 0) continue;
-			if (xofs >= width) break;
-
-			uint8_t val = glyph->bitmap[(row * glyph->cols) + col];
-			uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
-
-			*pixel = blend(*pixel, r, val);
-			pixel++;
-			*pixel = blend(*pixel, g, val);
-			pixel++;
-			*pixel = blend(*pixel, b, val);
+	if (font->compressed) {
+		unsigned out_length = 0, rows = glyph->rows, cols = glyph->cols;
+		const unsigned char * data = glyph->bitmap;
+		unsigned char count = 0, class = 0;
+		
+		for (int row = 0; row < rows; row++) {
+			int yofs = row + y + (font->ascender - glyph->top);
+			if ((yofs < 0) || (yofs >= height))
+				continue;
+			
+			for (int col = 0; col < cols; col++) {
+				int xofs = col + x + glyph->left;
+				if ((xofs < 0) || (xofs >= width))
+					break;
+				
+				if (count==0) {
+					count = (*data & 0x3f) + 1;
+					class = *(data++) >> 6;
+				}
+				
+				unsigned char val = 0;
+				if (class == 0)
+					val = *(data++);
+				else if (class == 3)
+					val = 0xff;
+				
+				uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
+				*pixel = blend(*pixel, r, val);
+				pixel++;
+				*pixel = blend(*pixel, g, val);
+				pixel++;
+				*pixel = blend(*pixel, b, val);
+			}
 		}
 	}
+	else {
+		for (int row = 0; row < glyph->rows; row++) {
+			int yofs = row + y + (font->ascender - glyph->top);
 
+			if (yofs < 0) continue;
+			if (yofs >= height) break;
+
+			for (int col = 0; col < glyph->cols; col++) {
+				int xofs = col + x + glyph->left;
+
+				if (xofs < 0) continue;
+				if (xofs >= width) break;
+
+				uint8_t val = glyph->bitmap[(row * glyph->cols) + col];
+				uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
+
+				*pixel = blend(*pixel, r, val);
+				pixel++;
+				*pixel = blend(*pixel, g, val);
+				pixel++;
+				*pixel = blend(*pixel, b, val);
+			}
+		}
+	}
+	
 	return glyph->advance;
 }
 

--- a/src/fontrender_rgba32.c
+++ b/src/fontrender_rgba32.c
@@ -23,19 +23,15 @@ int font_draw_glyph_RGBA32(const struct font *font,
 	uint8_t b = rgba32_get_b(rgb);
 	
 	if (font->compressed) {
-		unsigned out_length = 0, rows = glyph->rows, cols = glyph->cols;
+		unsigned rows = glyph->rows, cols = glyph->cols;
 		const unsigned char * data = glyph->bitmap;
 		unsigned char count = 0, class = 0;
 		
-		for (int row = 0; row < rows; row++) {
+		for (unsigned row = 0; row < rows; row++) {
 			int yofs = row + y + (font->ascender - glyph->top);
-			if ((yofs < 0) || (yofs >= height))
-				continue;
 			
-			for (int col = 0; col < cols; col++) {
+			for (unsigned col = 0; col < cols; col++) {
 				int xofs = col + x + glyph->left;
-				if ((xofs < 0) || (xofs >= width))
-					break;
 				
 				if (count==0) {
 					count = (*data & 0x3f) + 1;
@@ -47,13 +43,16 @@ int font_draw_glyph_RGBA32(const struct font *font,
 					val = *(data++);
 				else if (class == 3)
 					val = 0xff;
+				count--;
 				
-				uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
-				*pixel = blend(*pixel, r, val);
-				pixel++;
-				*pixel = blend(*pixel, g, val);
-				pixel++;
-				*pixel = blend(*pixel, b, val);
+				if ((yofs >= 0) && (yofs < height) && (xofs >= 0) && (xofs < width)) {
+					uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
+					*pixel = blend(*pixel, r, val);
+					pixel++;
+					*pixel = blend(*pixel, g, val);
+					pixel++;
+					*pixel = blend(*pixel, b, val);
+				}
 			}
 		}
 	}

--- a/src/fontrender_rgba32.c
+++ b/src/fontrender_rgba32.c
@@ -15,33 +15,37 @@
 
 int font_draw_glyph_RGBA32(const struct font *font,
 			   int x, int y, int width, int height,
-			   uint8_t *buf, const struct glyph *g,
+			   uint8_t *buf, const struct glyph *glyph,
 			   uint32_t rgb)
 {
-	for (int row = 0; row < g->rows; row++) {
-		int yofs = row + y + (font->ascender - g->top);
+	uint8_t r = rgba32_get_r(rgb);
+	uint8_t g = rgba32_get_g(rgb);
+	uint8_t b = rgba32_get_b(rgb);
+	
+	for (int row = 0; row < glyph->rows; row++) {
+		int yofs = row + y + (font->ascender - glyph->top);
 
 		if (yofs < 0) continue;
 		if (yofs >= height) break;
 
-		for (int col = 0; col < g->cols; col++) {
-			int xofs = col + x + g->left;
+		for (int col = 0; col < glyph->cols; col++) {
+			int xofs = col + x + glyph->left;
 
 			if (xofs < 0) continue;
 			if (xofs >= width) break;
 
-			uint8_t val = g->bitmap[(row * g->cols) + col];
+			uint8_t val = glyph->bitmap[(row * glyph->cols) + col];
 			uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
 
-			*pixel = alpha_blend(*pixel, 0, rgba32_get_r(rgb), val);
+			*pixel = blend(*pixel, r, val);
 			pixel++;
-			*pixel = alpha_blend(*pixel, 0, rgba32_get_g(rgb), val);
+			*pixel = blend(*pixel, g, val);
 			pixel++;
-			*pixel = alpha_blend(*pixel, 0, rgba32_get_b(rgb), val);
+			*pixel = blend(*pixel, b, val);
 		}
 	}
 
-	return g->advance;
+	return glyph->advance;
 }
 
 int font_draw_char_RGBA32(const struct font *font,

--- a/src/fontrender_rgba32.c
+++ b/src/fontrender_rgba32.c
@@ -22,56 +22,34 @@ int font_draw_glyph_RGBA32(const struct font *font,
 	uint8_t g = rgba32_get_g(rgb);
 	uint8_t b = rgba32_get_b(rgb);
 	
-	if (font->compressed) {
-		unsigned rows = glyph->rows, cols = glyph->cols;
-		const unsigned char * data = glyph->bitmap;
-		unsigned char count = 0, class = 0;
+	unsigned rows = glyph->rows, cols = glyph->cols;
+	const unsigned char * data = glyph->bitmap;
+	unsigned char count = 0, class = 0;
+	
+	for (unsigned row = 0; row < rows; row++) {
+		int yofs = row + y + (font->ascender - glyph->top);
 		
-		for (unsigned row = 0; row < rows; row++) {
-			int yofs = row + y + (font->ascender - glyph->top);
+		for (unsigned col = 0; col < cols; col++) {
+			unsigned char val = 0;
+			int xofs = col + x + glyph->left;
 			
-			for (unsigned col = 0; col < cols; col++) {
-				int xofs = col + x + glyph->left;
-				
+			if (font->compressed) {
 				if (count==0) {
 					count = (*data & 0x3f) + 1;
 					class = *(data++) >> 6;
 				}
 				
-				unsigned char val = 0;
 				if (class == 0)
 					val = *(data++);
 				else if (class == 3)
 					val = 0xff;
 				count--;
-				
-				if ((yofs >= 0) && (yofs < height) && (xofs >= 0) && (xofs < width)) {
-					uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
-					*pixel = blend(*pixel, r, val);
-					pixel++;
-					*pixel = blend(*pixel, g, val);
-					pixel++;
-					*pixel = blend(*pixel, b, val);
-				}
 			}
-		}
-	}
-	else {
-		for (int row = 0; row < glyph->rows; row++) {
-			int yofs = row + y + (font->ascender - glyph->top);
-
-			if (yofs < 0) continue;
-			if (yofs >= height) break;
-
-			for (int col = 0; col < glyph->cols; col++) {
-				int xofs = col + x + glyph->left;
-
-				if (xofs < 0) continue;
-				if (xofs >= width) break;
-
-				uint8_t val = glyph->bitmap[(row * glyph->cols) + col];
+			else
+				val = data[(row * cols) + col];
+			
+			if ((yofs >= 0) && (yofs < height) && (xofs >= 0) && (xofs < width)) {
 				uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
-
 				*pixel = blend(*pixel, r, val);
 				pixel++;
 				*pixel = blend(*pixel, g, val);

--- a/src/resource/fontem.h
+++ b/src/resource/fontem.h
@@ -76,6 +76,7 @@ struct font {
 	uint16_t		count;          /** Number of glyphs */
 	uint16_t		max;            /** Maximum glyph index */
 	const struct glyph	**glyphs;       /** Font glyphs */
+	char			compressed;
 };
 
 

--- a/src/resource/fontem.h
+++ b/src/resource/fontem.h
@@ -13,7 +13,9 @@
 
 /** Alpha compositing "A over B" mechanism */
 #define alpha_blend(in, in_alpha, out, out_alpha) \
-	(in * in_alpha + out * out_alpha * (255 - in_alpha))
+	((0x100 * in * in_alpha * (255 - out_alpha) + out * out_alpha * (255 - in_alpha)) >> 16)
+#define blend(a, b, alpha) \
+	(((a) * (255 - (alpha)) + (b) * (alpha)) >> 8)
 
 /** Extract the Alpha channel from a 32-bit RGBA value */
 #define rgba32_get_a(rgba) ((rgba >> 24) & 0xff)


### PR DESCRIPTION
Since character image consist mostly of 0x00 and 0xff, it is easy to compress it to save flash memory. Small (10 or 12) font with only ASCII charset does not occupy much size, but large (20 or 24) fonts with multiple codepages (Russian, Greek, Chinese, etc) will occupy very much space.

I implemented modified version of RLE algorithm. It is fast, and it allows to unpack characters on-the-fly without significant speed loss.

Comparison with uncompressed fonts (only contents were compared without ELF headers):

| Font                    | No      | mRLE   |
| ----------------------- | ------- | ------ |
| font-UbuntuMonoR-10.c:  | 9256    | 8648   |
| font-UbuntuMonoR-12.c:  | 11624   | 9832   |
| font-UbuntuMonoR-16.c:  | 15336   | 12872  |
| font-UbuntuMonoR-24.c:  | 29768   | 18024  |
| font-UbuntuMonoR-40.c:  | 75272   | 28840  |
| font-UbuntuMonoR-72.c:  | 230216  | 49960  |