### PR TITLE
RLE fixes

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -34,7 +34,7 @@ fonttest.c: $(fontout)/font_all.h
 fontdir := $(top_srcdir)/fonts
 fontout := fonts
 
-fonts_sources = \
+fonts_raw_sources := \
 	fonts/font-UbuntuMonoR-10.c \
 	fonts/font-UbuntuMonoR-16.c \
 	fonts/font-UbuntuMonoB-10.c \
@@ -42,22 +42,40 @@ fonts_sources = \
 	fonts/font-DejaVuSerif-10.c \
 	fonts/font-DejaVuSerif-16.c
 
-BUILT_SOURCES = $(fonts_sources) fonts/font_all.c
-libfonts_la_SOURCES = $(fonts_sources) fonts/font_all.c
+fonts_rle_sources := \
+	fonts/font-UbuntuMonoR-10-rle.c \
+	fonts/font-UbuntuMonoR-16-rle.c \
+	fonts/font-UbuntuMonoB-10-rle.c \
+	fonts/font-UbuntuMonoB-16-rle.c \
+	fonts/font-DejaVuSerif-10-rle.c \
+	fonts/font-DejaVuSerif-16-rle.c
+
+fonts_all_sources := $(fonts_raw_sources) $(fonts_rle_sources)
+
+BUILT_SOURCES = $(fonts_all_sources) fonts/font_all.c
+libfonts_la_SOURCES = $(fonts_all_sources) fonts/font_all.c
 libfonts_la_CPPFLAGS = -Iresource $(AM_CPPFLAGS)
 
 .SECONDEXPANSION:
-$(fonts_sources): %.c: $$(fontdir)/$$(word 2,$$(subst -, ,%)).ttf resource/fontem.h fontem
+$(fonts_raw_sources): %.c: $$(fontdir)/$$(word 2,$$(subst -, ,%)).ttf resource/fontem.h fontem
 	@mkdir -p $(fontout)
 	./fontem --font=$(fontdir)/$(word 2,$(subst -, ,$(notdir $@))).ttf \
-		--dir=$(fontout) --name=$(word 2,$(subst -, ,$(notdir $@))) --size=$(word 3,$(subst -, ,$(subst .c,,$(notdir $@))))
+		--dir=$(fontout) --name=$(word 2,$(subst -, ,$(notdir $@))) \
+		--size=$(word 3,$(subst -, ,$(subst .c,,$(notdir $@))))
 
-$(fontout)/font_all.h: $(fonts_sources) Makefile
+$(fonts_rle_sources): %.c: $$(fontdir)/$$(word 2,$$(subst -, ,%)).ttf resource/fontem.h fontem
+	@mkdir -p $(fontout)
+	./fontem --font=$(fontdir)/$(word 2,$(subst -, ,$(notdir $@))).ttf \
+		--dir=$(fontout) --name=$(word 2,$(subst -, ,$(notdir $@))) \
+		--size=$(word 3,$(subst -, ,$(subst .c,,$(notdir $@)))) \
+		--rle --append=-rle
+
+$(fontout)/font_all.h: $(fonts_all_sources) Makefile
 	@echo "/* A list of all font headers. */" > $@
 	@echo >> $@
 	@echo "#include \"fontem.h\"" >> $@
 	@echo >> $@
-	for font in $(sort $(notdir $(fonts_sources:%.c=%.h))); do echo "#include \"$$font\"" >> $@; done
+	for font in $(sort $(notdir $(fonts_all_sources:%.c=%.h))); do echo "#include \"$$font\"" >> $@; done
 	@echo >> $@
 	@echo "extern const struct font *fonts[];" >> $@
 	@echo "extern const int font_count;" >> $@
@@ -69,16 +87,16 @@ $(fontout)/font_all.c: $(fontout)/font_all.h Makefile
 	@echo "#include \"fontem.h\"" >> $@
 	@echo "#include \"font_all.h\"" >> $@
 	@echo >> $@
-	@echo "const int font_count = $(words $(fonts_sources));" >> $@
+	@echo "const int font_count = $(words $(fonts_all_sources));" >> $@
 	@echo >> $@
 	@echo "const struct font *fonts[] = {" >> $@
-	for font in $(sort $(subst -,_,$(notdir $(fonts_sources:%.c=%)))); do printf "\t&$$font,\n" >> $@; done
+	for font in $(sort $(subst -,_,$(notdir $(fonts_all_sources:%.c=%)))); do printf "\t&$$font,\n" >> $@; done
 	@printf "\tNULL\n" >> $@
 	@echo "};" >> $@
 
 
 clean-local:
-	rm -f $(fonts_sources) $(fonts_sources:.c=.h) $(fontout)/font_all.h $(fontout)/font_all.c
+	rm -f $(fonts_all_sources) $(fonts_all_sources:.c=.h) $(fontout)/font_all.h $(fontout)/font_all.c
 
 distclean-local:
 	rm -f Makefile.in

--- a/src/fontfinder.c
+++ b/src/fontfinder.c
@@ -19,27 +19,37 @@
 #define EOL "\n"
 #endif
 
-const struct font *font_find(const char *name, const char *style, const int size)
+/** Find a font based on name, style size and whether it is compressed. */
+const struct font *font_find_all(const char *name, const char *style, const int size,
+				 const char rle)
 {
 	for (int idx = 0; fonts[idx] != NULL; idx++) {
 		if (size == fonts[idx]->size && !strcasecmp(name, fonts[idx]->name))
 			if (style == NULL || !strcasecmp(style, fonts[idx]->style))
-				return fonts[idx];
+				if (rle < 0 || rle == fonts[idx]->compressed)
+					return fonts[idx];
 	}
 	return NULL;
 }
 
+/** Find a font based on name, style and size. */
+const struct font *font_find(const char *name, const char *style, const int size)
+{
+	return font_find_all(name, style, size, -1);
+}
+
 void font_print_all(FILE *out)
 {
-	fprintf(out, "%-20s %-8s %-6s %-6s %-6s" EOL,
+	fprintf(out, "%-20s %-8s %-6s %-6s %-6s %-3s" EOL,
 		"Font name", "Style", "Size",
-		"Vdist", "Height");
+		"Vdist", "Height", "RLE");
 	for (int idx = 0; fonts[idx] != NULL; idx++) {
-		fprintf(out, "%-20s %-8s %6d %6d %6d" EOL,
+		fprintf(out, "%-20s %-8s %-6d %-6d %-6d %-3c" EOL,
 			fonts[idx]->name,
 			fonts[idx]->style,
 			fonts[idx]->size,
 			fonts[idx]->height,
-			fonts[idx]->ascender + fonts[idx]->descender);
+			fonts[idx]->ascender + fonts[idx]->descender,
+			fonts[idx]->compressed ? 'Y' : ' ');
 	}
 }

--- a/src/fontrender.c
+++ b/src/fontrender.c
@@ -17,10 +17,10 @@ const struct glyph *font_get_glyph(const struct font *font, glyph_t glyph)
 {
 	if (glyph > font->max)
 		return NULL;
-	
+
 	size_t first = 0, last = font->count;
-	const struct glyph ** glyphs = font->glyphs;
-	
+	const struct glyph **glyphs = font->glyphs;
+
 	while (first < last) {
 		size_t mid = first + (last - first) / 2;
 		if (glyph <= glyphs[mid]->glyph)
@@ -28,7 +28,7 @@ const struct glyph *font_get_glyph(const struct font *font, glyph_t glyph)
 		else
 			first = mid + 1;
 	}
-	
+
 	return (last < font->count && glyphs[last]->glyph == glyph) ? *(glyphs + last) : NULL;
 }
 

--- a/src/fontrender_rgb16.c
+++ b/src/fontrender_rgb16.c
@@ -15,33 +15,50 @@
 
 int font_draw_glyph_RGB16(const struct font *font,
 			  int x, int y, int width, int height,
-			  uint8_t *buf, const struct glyph *g,
+			  uint8_t *buf, const struct glyph *glyph,
 			  uint16_t rgb)
 {
-	for (int row = 0; row < g->rows; row++) {
-		int yofs = row + y + (font->ascender - g->top);
+	unsigned int rows = glyph->rows, cols = glyph->cols;
+	const unsigned char *data = glyph->bitmap;
+	unsigned char count = 0, class = 0;
 
-		if (yofs < 0) continue;
-		if (yofs >= height) break;
+	for (unsigned int row = 0; row < rows; row++) {
+		int yofs = row + y + (font->ascender - glyph->top);
 
-		for (int col = 0; col < g->cols; col++) {
-			int xofs = col + x + g->left;
+		for (unsigned int col = 0; col < cols; col++) {
+			int xofs = col + x + glyph->left;
 
-			if (xofs < 0) continue;
-			if (xofs >= width) break;
+			uint8_t val;
+			if (font->compressed) {
+				if (count == 0) {
+					count = (*data & 0x3f) + 1;
+					class = *(data++) >> 6;
+				}
 
-			uint16_t val = g->bitmap[(row * g->cols) + col];
-			uint16_t *pixel = (uint16_t *)(buf + (yofs * width * 2) + (xofs * 2));
+				if (class == 0)
+					val = *(data++);
+				else if (class == 3)
+					val = 0xff;
+				else
+					val = 0;
+				count--;
+			} else {
+				val = data[(row * glyph->cols) + col];
+			}
 
-			uint16_t r = alpha_blend(rgb16_get_r(*pixel), 0, rgb16_get_r(rgb), val);
-			uint16_t g = alpha_blend(rgb16_get_g(*pixel), 0, rgb16_get_g(rgb), val);
-			uint16_t b = alpha_blend(rgb16_get_b(*pixel), 0, rgb16_get_b(rgb), val);
+			if ((yofs >= 0) && (yofs < height) && (xofs >= 0) && (xofs < width)) {
+				uint16_t *pixel = (uint16_t *)(buf + (yofs * width * 2) + (xofs * 2));
 
-			*pixel = rgb16_combine(r, g, b);
+				uint16_t r = alpha_blend(rgb16_get_r(*pixel), 0, rgb16_get_r(rgb), val);
+				uint16_t g = alpha_blend(rgb16_get_g(*pixel), 0, rgb16_get_g(rgb), val);
+				uint16_t b = alpha_blend(rgb16_get_b(*pixel), 0, rgb16_get_b(rgb), val);
+
+				*pixel = rgb16_combine(r, g, b);
+			}
 		}
 	}
 
-	return g->advance;
+	return glyph->advance;
 }
 
 int font_draw_char_RGB16(const struct font *font,

--- a/src/fontrender_rgba32.c
+++ b/src/fontrender_rgba32.c
@@ -21,33 +21,35 @@ int font_draw_glyph_RGBA32(const struct font *font,
 	uint8_t r = rgba32_get_r(rgb);
 	uint8_t g = rgba32_get_g(rgb);
 	uint8_t b = rgba32_get_b(rgb);
-	
+
 	unsigned rows = glyph->rows, cols = glyph->cols;
-	const unsigned char * data = glyph->bitmap;
+	const unsigned char *data = glyph->bitmap;
 	unsigned char count = 0, class = 0;
-	
+
 	for (unsigned row = 0; row < rows; row++) {
 		int yofs = row + y + (font->ascender - glyph->top);
-		
+
 		for (unsigned col = 0; col < cols; col++) {
-			unsigned char val = 0;
 			int xofs = col + x + glyph->left;
-			
+
+			uint8_t val;
 			if (font->compressed) {
-				if (count==0) {
+				if (count == 0) {
 					count = (*data & 0x3f) + 1;
 					class = *(data++) >> 6;
 				}
-				
+
 				if (class == 0)
 					val = *(data++);
 				else if (class == 3)
 					val = 0xff;
+				else
+					val = 0;
 				count--;
-			}
-			else
+			} else {
 				val = data[(row * cols) + col];
-			
+			}
+
 			if ((yofs >= 0) && (yofs < height) && (xofs >= 0) && (xofs < width)) {
 				uint8_t *pixel = buf + (yofs * width * 3) + (xofs * 3);
 				*pixel = blend(*pixel, r, val);
@@ -58,7 +60,7 @@ int font_draw_glyph_RGBA32(const struct font *font,
 			}
 		}
 	}
-	
+
 	return glyph->advance;
 }
 

--- a/src/fonttest.c
+++ b/src/fonttest.c
@@ -22,17 +22,19 @@ int main(int argc, const char *argv[])
 	char *font_name = "DejaVu Serif";
 	char *font_style = NULL;
 	int font_size = 10;
+	int font_rle = -1;
 	int width = -1;
 	int height = -1;
 
 	struct poptOption opts[] = {
-		{ "text",      't', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &string,     1, "String to render",	     "text"  },
-		{ "fontname",  'f', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_name,  1, "Name of the font to use",  "font"  },
-		{ "fontstyle", 'S', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_style, 1, "Style of the font to use", "style" },
-		{ "fontsize",  's', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &font_size,  1, "Size of the fonr to use",  "pts"   },
-		{ "width",     'w', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &width,      1, "Canvas width",	     "chars" },
-		{ "height",    'h', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &height,     1, "Canvas height",	     "chars" },
-		{ "list",      'l', 0,						 NULL,	      2, "List available fonts",     NULL    },
+		{ "text",      't', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &string,     1, "String to render",		       "text"  },
+		{ "fontname",  'f', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_name,  1, "Name of the font to use",	       "font"  },
+		{ "fontstyle", 'S', POPT_ARG_STRING | POPT_ARGFLAG_SHOW_DEFAULT, &font_style, 1, "Style of the font to use",	       "style" },
+		{ "fontsize",  's', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &font_size,  1, "Size of the fonr to use",	       "pts"   },
+		{ "fontrle",   'r', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &font_rle,   1, "0 = no RLE, 1 = RLE only, -1 = any", "mode"  },
+		{ "width",     'w', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &width,      1, "Canvas width",		       "chars" },
+		{ "height",    'h', POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT,	 &height,     1, "Canvas height",		       "chars" },
+		{ "list",      'l', 0,						 NULL,	      2, "List available fonts",	       NULL    },
 		POPT_AUTOHELP
 		POPT_TABLEEND
 	};
@@ -60,7 +62,7 @@ int main(int argc, const char *argv[])
 		return 1;
 	}
 
-	const struct font *font = font_find(font_name, font_style, font_size);
+	const struct font *font = font_find_all(font_name, font_style, font_size, (char)font_rle);
 
 	if (font == NULL) {
 		fprintf(stderr, "ERROR: Unable to find a font matching \"%s\" size \"%d\".\n",
@@ -75,8 +77,8 @@ int main(int argc, const char *argv[])
 		if (height == -1) height = h;
 	}
 
-	uint8_t *canvas = malloc(width * height);
-	memset(canvas, ' ', width * height);
+	uint8_t *canvas = malloc((size_t)width * (size_t)height);
+	memset(canvas, ' ', (size_t)width * (size_t)height);
 
 	char *p = string;
 

--- a/src/resource/fontem.h
+++ b/src/resource/fontem.h
@@ -78,7 +78,7 @@ struct font {
 	uint16_t		count;          /** Number of glyphs */
 	uint16_t		max;            /** Maximum glyph index */
 	const struct glyph	**glyphs;       /** Font glyphs */
-	char			compressed;
+	char			compressed;     /** TRUE if glyph bitmaps are RLE compressed */
 };
 
 
@@ -101,6 +101,7 @@ int font_draw_char_RGB16(const struct font *font, int x, int y, int width, int h
 char *font_draw_string_RGB16(const struct font *font, int x, int y, int width, int height, uint8_t *buf, char *str, char prev, uint16_t rgb);
 
 /* fontfind.c */
+const struct font *font_find_all(const char *name, const char *style, const int size, const char rle);
 const struct font *font_find(const char *name, const char *style, const int size);
 void font_print_all(FILE *out);
 


### PR DESCRIPTION
- Implement RLE for 1bit and rgb16 renderers.
- Minor refactoring for readability.
- Build fonttest with both uncompressed and RLE compressed fonts.
- Add mechanism to append a string to the generated filename and
  font index (eg, for RLE fonts). C-ifies it, so '-rle' becomes
 '_rle' in the generated code.
- Uncrustify everything.