### PR TITLE
Fix a no-op warning

### DIFF
--- a/src/fontem.c
+++ b/src/fontem.c
@@ -95,6 +95,13 @@ int main(int argc, const char *argv[])
 
 	while ((rc = poptGetNextOpt(ctx)) > 0) {
 		switch (rc) {
+		case 1:
+			/* No-op */
+			break;
+
+		default:
+			fprintf(stderr, "ERROR: Unexpected option value '%d'.\n", rc);
+			return 1;
 		}
 	}
 


### PR DESCRIPTION
- The popt processing loop normally looks for option values given
  in the options structure; however all our values are "1" meaning
  no code was implemented in this loop to do anything.
- To please the static analyzer, but not lose the logic of the loop,
  have it check for any unexpected values.